### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"dependencies": {
 		"axios": "1.3.4",
 		"bulma": "0.9.4",
-		"cydran": "file:../cydran",
+		"cydran": "0.2.1",
 		"markdown": "^0.5.0",
 		"navigo": "^7.1.2"
 	}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"devDependencies": {
-		"@babel/core": "7.16.5",
+		"@babel/core": "7.21.3",
 		"animate.css": "4.1.1",
 		"babel-core": "6.26.3",
 		"babel-loader": "8.2.3",
@@ -29,24 +29,24 @@
 		"contents-loader": "^1.0.0",
 		"copy-webpack-plugin": "6.1.0",
 		"css-loader": "4.3.0",
-		"file-loader": "6.1.0",
+		"file-loader": "6.2.0",
 		"html-webpack-plugin": "4.4.1",
 		"mini-css-extract-plugin": "0.11.1",
-		"raw-loader": "4.0.1",
+		"raw-loader": "4.0.2",
 		"rimraf": "3.0.2",
-		"sass": "1.49.0",
+		"sass": "1.59.3",
 		"sass-loader": "10.0.2",
 		"style-loader": "1.2.1",
 		"ts-loader": "8.0.3",
-		"typescript": "4.0.2",
+		"typescript": "5.0.2",
 		"webpack": "4.44.1",
 		"webpack-cli": "3.3.12",
 		"webpack-dev-server": "3.11.0"
 	},
 	"dependencies": {
 		"axios": "0.20.0",
-		"bulma": "0.9.3",
-		"cydran": "0.2.1",
+		"bulma": "0.9.4",
+		"cydran": "file:../cydran",
 		"markdown": "^0.5.0",
 		"navigo": "^7.1.2"
 	}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"html-webpack-plugin": "4.4.1",
 		"mini-css-extract-plugin": "0.11.1",
 		"raw-loader": "4.0.2",
-		"rimraf": "3.0.2",
+		"rimraf": "4.4.0",
 		"sass": "1.59.3",
 		"sass-loader": "10.0.2",
 		"style-loader": "1.2.1",
@@ -44,7 +44,7 @@
 		"webpack-dev-server": "3.11.0"
 	},
 	"dependencies": {
-		"axios": "0.20.0",
+		"axios": "1.3.4",
 		"bulma": "0.9.4",
 		"cydran": "file:../cydran",
 		"markdown": "^0.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,10 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
+const crypto = require("crypto");
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 const htmlWebpackPlugin = new HtmlWebPackPlugin({
 	template: "./src/index.html",


### PR DESCRIPTION
Navigo still has major upgrade, but breaks the functionality and build.  Resolving will be  working through the API changes.  Webpack also has big upgrade but missing some previously included polyfills.  Webpack plugins and subsequent supporting libs are tied to the webpack version. Everything else seems to have transitioned ok.